### PR TITLE
Refactor: Modernize website styling and visual appeal

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,8 +19,7 @@
 
     <!-- Custom Fonts -->
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,700,400italic,700italic|Roboto+Slab:400,700' rel='stylesheet' type='text/css'>
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">
 	
 	<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -19,8 +19,7 @@
 
     <!-- Custom Fonts -->
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,700,400italic,700italic|Roboto+Slab:400,700' rel='stylesheet' type='text/css'>
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">
 	
 	<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -61,8 +60,6 @@
             </div>
         </div>
     </article>
-
-    <hr>
 
 	{% include footer.html %}
     <!-- jQuery -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,8 +19,7 @@
 
     <!-- Custom Fonts -->
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,700,400italic,700italic|Roboto+Slab:400,700' rel='stylesheet' type='text/css'>
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">
 	
 	<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -68,8 +67,6 @@
             </div>
         </div>
     </article>
-
-    <hr>
 
 	{% include footer.html %}
     <!-- jQuery -->

--- a/css/clean-blog.css
+++ b/css/clean-blog.css
@@ -5,13 +5,12 @@
  */
 
 body {
-  /*font-family: 'Lora', 'Times New Roman', serif;*/
-  
-  font-size: 20px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 18px;
   color: #404040;
 }
 p {
-  line-height: 1.5;
+  line-height: 1.6;
   margin: 30px 0;
 }
 p a {
@@ -23,15 +22,15 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 800;
+  font-family: 'Roboto Slab', serif;
+  font-weight: 700;
 }
 a {
   color: #404040;
 }
 a:hover,
 a:focus {
-  color: #0085a1;
+  color: #1dc8e2;
 }
 a img:hover,
 a img:focus {
@@ -45,7 +44,7 @@ hr.small {
   max-width: 100px;
   margin: 15px auto;
   border-width: 4px;
-  border-color: white;
+  border-color: #17a2b8;
 }
 .navbar-custom {
   position: absolute;
@@ -53,15 +52,15 @@ hr.small {
   left: 0;
   width: 100%;
   z-index: 3;
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Roboto Slab', sans-serif;
 }
 .navbar-custom .navbar-brand {
-  font-weight: 800;
+  font-weight: 700;
 }
 .navbar-custom .nav li a {
   text-transform: uppercase;
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 1px;
 }
 @media only screen and (min-width: 768px) {
@@ -115,14 +114,14 @@ hr.small {
   }
   .navbar-custom.is-fixed .navbar-brand:hover,
   .navbar-custom.is-fixed .navbar-brand:focus {
-    color: #0085a1;
+    color: #1dc8e2;
   }
   .navbar-custom.is-fixed .nav li a {
     color: #404040;
   }
   .navbar-custom.is-fixed .nav li a:hover,
   .navbar-custom.is-fixed .nav li a:focus {
-    color: #0085a1;
+    color: #1dc8e2;
   }
   .navbar-custom.is-visible {
     /* if the user changes the scrolling direction, we show the header */
@@ -143,12 +142,27 @@ hr.small {
   background-size: cover;
   -o-background-size: cover;
   margin-bottom: 50px;
+  position: relative; /* For pseudo-element overlay */
 }
+
+.intro-header::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1; 
+}
+
 .intro-header .site-heading,
 .intro-header .post-heading,
 .intro-header .page-heading {
   padding: 100px 0 50px;
   color: white;
+  position: relative; /* Ensure content is above the overlay */
+  z-index: 2;
 }
 @media only screen and (min-width: 768px) {
   .intro-header .site-heading,
@@ -171,7 +185,7 @@ hr.small {
   font-size: 24px;
   line-height: 1.1;
   display: block;
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Roboto Slab', sans-serif;
   font-weight: 300;
   margin: 10px 0 0;
 }
@@ -190,13 +204,13 @@ hr.small {
   display: block;
 }
 .intro-header .post-heading .subheading {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Roboto Slab', sans-serif;
   font-size: 24px;
   margin: 10px 0 30px;
   font-weight: 600;
 }
 .intro-header .post-heading .meta {
-  /*font-family: 'Lora', 'Times New Roman', serif;*/
+  font-family: 'Roboto', serif;
   font-style: italic;
   font-weight: 300;
   font-size: 20px;
@@ -212,20 +226,42 @@ hr.small {
     font-size: 30px;
   }
 }
+
+/* Post Preview Card Styling */
+.post-preview {
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 30px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+  transition: box-shadow 0.3s ease-in-out;
+}
+
+.post-preview:hover,
+.post-preview:focus {
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+}
+
+.post-preview + hr {
+  display: none;
+}
+
 .post-preview > a {
   color: #404040;
 }
 .post-preview > a:hover,
 .post-preview > a:focus {
   text-decoration: none;
-  color: #0085a1;
+  color: #1dc8e2;
 }
 .post-preview > a > .post-title {
+  font-family: 'Roboto Slab', serif;
   font-size: 30px;
-  margin-top: 30px;
+  margin-top: 10px;
   margin-bottom: 10px;
 }
 .post-preview > a > .post-subtitle {
+  font-family: 'Roboto', sans-serif;
   margin: 0;
   font-weight: 300;
   margin-bottom: 10px;
@@ -235,6 +271,8 @@ hr.small {
   font-size: 18px;
   font-style: italic;
   margin-top: 0;
+  /* Adjusting padding for post-meta as .post-preview now has padding */
+  padding-bottom: 10px; 
 }
 .post-preview > .post-meta > a {
   text-decoration: none;
@@ -242,7 +280,7 @@ hr.small {
 }
 .post-preview > .post-meta > a:hover,
 .post-preview > .post-meta > a:focus {
-  color: #0085a1;
+  color: #1dc8e2;
   text-decoration: underline;
 }
 @media only screen and (min-width: 768px) {
@@ -322,13 +360,13 @@ footer .copyright {
   opacity: 1;
 }
 .floating-label-form-group-with-focus label {
-  color: #0085a1;
+  color: #17a2b8;
 }
 form .row:first-child .floating-label-form-group {
   border-top: 1px solid #eeeeee;
 }
 .btn {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Roboto Slab', sans-serif;
   text-transform: uppercase;
   font-size: 14px;
   font-weight: 800;
@@ -342,8 +380,8 @@ form .row:first-child .floating-label-form-group {
 }
 .btn-default:hover,
 .btn-default:focus {
-  background-color: #0085a1;
-  border: 1px solid #0085a1;
+  background-color: #1dc8e2;
+  border: 1px solid #1dc8e2;
   color: white;
 }
 .pager {
@@ -351,7 +389,7 @@ form .row:first-child .floating-label-form-group {
 }
 .pager li > a,
 .pager li > span {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Roboto Slab', sans-serif;
   text-transform: uppercase;
   font-size: 14px;
   font-weight: 800;
@@ -363,8 +401,8 @@ form .row:first-child .floating-label-form-group {
 .pager li > a:hover,
 .pager li > a:focus {
   color: white;
-  background-color: #0085a1;
-  border: 1px solid #0085a1;
+  background-color: #1dc8e2;
+  border: 1px solid #1dc8e2;
 }
 .pager .disabled > a,
 .pager .disabled > a:hover,
@@ -377,12 +415,12 @@ form .row:first-child .floating-label-form-group {
 ::-moz-selection {
   color: white;
   text-shadow: none;
-  background: #0085a1;
+  background: #17a2b8;
 }
 ::selection {
   color: white;
   text-shadow: none;
-  background: #0085a1;
+  background: #17a2b8;
 }
 img::selection {
   color: white;
@@ -393,7 +431,7 @@ img::-moz-selection {
   background: transparent;
 }
 body {
-  webkit-tap-highlight-color: #0085a1;
+  webkit-tap-highlight-color: #17a2b8;
 }
 
 .post-container img {


### PR DESCRIPTION
This commit introduces a more modern and visually appealing design to the GitHub Pages site.

Key changes include:

- Updated Color Palette: Replaced the old blue accent with a vibrant teal (#17a2b8) and a lighter shade for hovers (#1dc8e2).
- Refreshed Typography:
    - Changed heading font to 'Roboto Slab' and body font to 'Roboto'.
    - Adjusted font sizes, weights, and line heights for improved readability and visual hierarchy.
    - Ensured consistent font imports across all layout files.
- Enhanced Post Previews:
    - Styled post previews on the homepage with a card-like design, including borders, rounded corners, and box shadows.
    - Added subtle hover effects to post preview cards.
    - Removed horizontal rule separators between posts, relying on card styling for visual separation.
- Modernized Header:
    - Added a semi-transparent dark overlay to the main header's background image to improve text contrast.
    - Updated the color of the `hr.small` element in the header to match the new accent color.
- General Refinements:
    - Removed unnecessary `<hr>` elements from post and page layouts.
    - Corrected font weights for navbar elements to align with available font styles.

These changes aim to provide a cleaner, more contemporary user experience while maintaining the core content and structure of the blog.